### PR TITLE
Remove apt install of Boost from Azure build

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 [![Build Status](https://dev.azure.com/HELICS-test/helics-ns3/_apis/build/status/GMLC-TDC.helics-ns3?branchName=master)](https://dev.azure.com/HELICS-test/helics-ns3/_build/latest?definitionId=1?branchName=master)
 
-helics-ns3 is an [ns-3](https://www.nsnam.org/) module for coupling network simulations with other simulators using [HELICS](https://www.helics.org/).
+[helics-ns3](https://github.com/GMLC-TDC/helics-ns3) is an [ns-3](https://www.nsnam.org/) module for coupling network simulations with other simulators using [HELICS](https://www.helics.org/).
 
 ## Prerequisites
 
-Install a recent 2.x version of [HELICS](https://github.com/GMLC-TDC/HELICS-src).
+Install version 2.1+ of [HELICS](https://github.com/GMLC-TDC/HELICS-src); if building from source, be sure to set the CMake variable `JSONCPP_OBJLIB=ON` .
 
-Get a copy of the latest development version of ns-3 from their GitLab repository. (With older ns-3 versions from 3.28 through Dec 6, 2018 [post 3.29] a bug with finding Boost libraries will prevent the HELICS module from working)
+Get a recent copy of ns-3, ideally from their GitLab repository.
 
 Git:
 ```bash
@@ -24,7 +24,7 @@ cd ns-3-dev/
 git clone https://github.com/GMLC-TDC/helics-ns3 contrib/helics
 ```
 
-Run `./waf configure` with the `--disable-werror` option, and set the `--with-helics` option to the path of your HELICS installation. To enable examples or tests use `--enable-examples` or `--enable-tests`, respectively. If the system copy of Boost was not used to build HELICS (or there are several versions of Boost installed), then use the `--boost-includes` and `--boost-libs` options to tell waf where the copy of Boost to use is located. If ZMQ is not found, `--with-zmq` can be used to specify where it is installed. Paths should be absolute.
+Run `./waf configure` with the `--disable-werror` option, and set the `--with-helics` option to the path of your HELICS installation. To enable examples or tests use `--enable-examples` or `--enable-tests`, respectively. If ZMQ is not found, `--with-zmq` can be used to specify where it is installed. Paths should be absolute.
 
 After configuration is done, run `./waf build` to compile ns-3 with the HELICS module.
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,6 @@
 trigger:
 - master
+- develop
 
 pool:
   vmImage: 'Ubuntu-16.04'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,14 +17,17 @@ steps:
   displayName: 'Apt install required Boost and ZeroMQ libraries'
 
 - script: |
-    ls /usr/local/share/boost/1.69.0
-    ls /usr/local
-    ls /usr/local/boost
+    echo "share/lib:"
+    ls /usr/local/share/boost/1.69.0/lib
+    echo "share/libs:"
+    ls /usr/local/share/boost/1.69.0/libs
+    echo "usr/local/lib:"
+    ls /usr/local/lib
     git clone https://github.com/GMLC-TDC/HELICS-src
     cd HELICS-src
     mkdir build
     cd build
-    cmake -GNinja ../ -DBUILD_HELICS_TESTS=OFF -DBUILD_HELICS_EXAMPLES=OFF
+    cmake -GNinja ../ -DBUILD_HELICS_TESTS=OFF -DBUILD_HELICS_EXAMPLES=OFF -DBOOST_INSTALL_PATH=/usr/local/share/boost/1.69.0
     ninja
     sudo ninja install
   displayName: 'Install HELICS'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,6 +20,7 @@ steps:
     cmake --version
     git clone https://github.com/GMLC-TDC/HELICS-src
     cd HELICS-src
+    git checkout develop
     mkdir build
     cd build
     cmake -GNinja ../ -DBUILD_HELICS_TESTS=OFF -DBUILD_HELICS_EXAMPLES=OFF

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,6 +21,7 @@ steps:
     git clone https://github.com/GMLC-TDC/HELICS-src
     cd HELICS-src
     git checkout develop
+    git submodule update --init --recursive
     mkdir build
     cd build
     cmake -GNinja ../ -DBUILD_HELICS_TESTS=OFF -DBUILD_HELICS_EXAMPLES=OFF

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,7 +22,7 @@ steps:
     cd HELICS-src
     mkdir build
     cd build
-    cmake -GNinja ../ -DBUILD_HELICS_TESTS=OFF -DBUILD_HELICS_EXAMPLES=OFF -DBOOST_LIBRARYDIR=/usr/local/share/boost/1.69.0
+    cmake -GNinja ../ -DBUILD_HELICS_TESTS=OFF -DBUILD_HELICS_EXAMPLES=OFF
     ninja
     sudo ninja install
   displayName: 'Install HELICS'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,10 +13,13 @@ steps:
   displayName: 'Move helics-ns3 module files into subfolder'
 
 - script: |
-    sudo apt-get install -y libboost-dev libboost-signals-dev libboost-test-dev libboost-program-options-dev libboost-filesystem-dev libboost-system-dev libboost-date-time-dev libboost-timer-dev libboost-chrono-dev libzmq5-dev ninja-build
+    sudo apt-get install -y  libzmq5-dev ninja-build
   displayName: 'Apt install required Boost and ZeroMQ libraries'
 
 - script: |
+    ls /usr/local/share/boost/1.69.0
+    ls /usr/local
+    ls /usr/local/boost
     git clone https://github.com/GMLC-TDC/HELICS-src
     cd HELICS-src
     mkdir build

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,17 +17,12 @@ steps:
   displayName: 'Apt install required Boost and ZeroMQ libraries'
 
 - script: |
-    echo "share/lib:"
-    ls /usr/local/share/boost/1.69.0/lib
-    echo "share/libs:"
-    ls /usr/local/share/boost/1.69.0/libs
-    echo "usr/local/lib:"
-    ls /usr/local/lib
+    cmake --version
     git clone https://github.com/GMLC-TDC/HELICS-src
     cd HELICS-src
     mkdir build
     cd build
-    cmake -GNinja ../ -DBUILD_HELICS_TESTS=OFF -DBUILD_HELICS_EXAMPLES=OFF -DBOOST_INSTALL_PATH=/usr/local/share/boost/1.69.0
+    cmake -GNinja ../ -DBUILD_HELICS_TESTS=OFF -DBUILD_HELICS_EXAMPLES=OFF -DBOOST_LIBRARYDIR=/usr/local/share/boost/1.69.0
     ninja
     sudo ninja install
   displayName: 'Install HELICS'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,7 +15,8 @@ steps:
 
 - script: |
     sudo apt-get install -y  libzmq5-dev ninja-build
-  displayName: 'Apt install required Boost and ZeroMQ libraries'
+  # Boost is pre-installed on Azure
+  displayName: 'Apt install required ZeroMQ libraries'
 
 - script: |
     cmake --version

--- a/examples/fed-filter.cc
+++ b/examples/fed-filter.cc
@@ -18,46 +18,42 @@
 #include <set>
 #include <thread>
 #include <stdexcept>
-#include <boost/filesystem.hpp>
-#include <boost/program_options.hpp>
+#include "helics/core/helicsCLI11.hpp"
 #include "helics/core/BrokerFactory.hpp"
 #include "helics/core/helicsVersion.hpp"
 
-namespace po = boost::program_options;
-namespace filesystem = boost::filesystem;
-
-static bool argumentParser (int argc, const char * const *argv, po::variables_map &vm_map);
-
-
 int main (int argc, char *argv[])
 {
-    po::variables_map vm;
-    if (argumentParser (argc, argv, vm)) {
-        return 0;
-    }
-
+    helics::helicsCLI11App app ("Filter Fed NS3 Example", "FilterFedNS3Example");
     std::string myname = "fed";
-    if (vm.count("name") > 0)
-    {
-        myname = vm["name"].as<std::string>();
-    }
     std::string srcEndpoint = "endpoint1";
-    if (vm.count("endpoint1") > 0) {
-        srcEndpoint = vm["endpoint1"].as<std::string>();
-    }
     std::string dstEndpoint = "endpoint2";
-    if (vm.count("endpoint2") > 0)
-    {
-        dstEndpoint = vm["endpoint2"].as<std::string>();
-    }
+    std::string brokerArgs = "";
+
+    app.add_option ("--name,-n", myname, "name of this federate");
+    app.add_option ("--endpoint1,--source,-s", srcEndpoint, "name of the source endpoint");
+    app.add_option ("--endpoint2,--dest,-d", dstEndpoint, "name of the destination endpoint");
+    app.add_option ("--startbroker", brokerArgs, "start a broker with the specified arguments");
+
+    auto ret = app.helics_parse (argc, argv);
 
     helics::FederateInfo fi {};
+    if (ret == helics::helicsCLI11App::parse_return::help_return)
+    {
+        fi.loadInfoFromArgs ("--help");
+        return 0;
+    }
+    else if (ret != helics::helicsCLI11App::parse_return::ok)
+    {
+        return -1;
+    }
+    fi.defName = "filterFedNS3";
     fi.loadInfoFromArgs(argc, argv);
     fi.setProperty(helics_property_time_delta, helics::loadTimeFromString("1s"));
     std::shared_ptr<helics::Broker> brk;
-    if (vm.count("startbroker") > 0)
+    if (app["--startbroker"]->count () > 0)
     {
-        brk = helics::BrokerFactory::create(fi.coreType, vm["startbroker"].as<std::string>());
+        brk = helics::BrokerFactory::create(fi.coreType, brokerArgs);
     }
 
     auto mFed = std::make_unique<helics::MessageFederate> (myname, fi);
@@ -96,54 +92,4 @@ int main (int argc, char *argv[])
         brk = nullptr;
     }
     return 0;
-}
-
-bool argumentParser (int argc, const char * const *argv, po::variables_map &vm_map)
-{
-    po::options_description opt ("options");
-
-    // clang-format off
-    // input boost controls
-    opt.add_options()
-        ("help,h", "produce help message")
-        ("startbroker", po::value<std::string>(),"start a broker with the specified arguments")
-        ("name,n", po::value<std::string>(), "name of this federate")
-        ("endpoint1,s", po::value<std::string>(), "name of the source endpoint")
-        ("endpoint2,d", po::value<std::string>(), "name of the destination endpoint");
-
-    // clang-format on
-
-    po::variables_map cmd_vm;
-    try
-    {
-        po::store (po::command_line_parser (argc, argv).options (opt).allow_unregistered().run (), cmd_vm);
-    }
-    catch (std::exception &e)
-    {
-        std::cerr << e.what () << std::endl;
-        throw (e);
-    }
-
-    po::notify (cmd_vm);
-
-    // objects/pointers/variables/constants
-
-    // program options control
-    if (cmd_vm.count ("help") > 0)
-    {
-        std::cout << opt << '\n';
-        return true;
-    }
-
-    if (cmd_vm.count ("version") > 0)
-    {
-        std::cout << helics::versionString << '\n';
-        return true;
-    }
-
-    po::store (po::command_line_parser (argc, argv).options (opt).allow_unregistered().run (), vm_map);
-
-    po::notify (vm_map);
-
-    return false;
 }

--- a/helper/helics-helper.cc
+++ b/helper/helics-helper.cc
@@ -58,7 +58,7 @@ HelicsHelper::SetupFederate(void) {
 // timeDelta = timeEpsilon (minimum time advance allowed by federate)
 // outputDelay, inputDelay, period, offset = timeZero
 void
-HelicsHelper::SetupFederate(int argc, const char *const *argv)
+HelicsHelper::SetupFederate(int argc, char **argv)
 {
   helics::FederateInfo fi (argc, argv);
   helics_federate = std::make_shared<helics::MessageFederate> (name, fi);

--- a/helper/helics-helper.h
+++ b/helper/helics-helper.h
@@ -14,7 +14,7 @@ class HelicsHelper {
 public:
   HelicsHelper ();
   void SetupFederate (void);
-  void SetupFederate (int argc, const char *const *argv);
+  void SetupFederate (int argc, char **argv);
   void SetupFederate (std::string &jsonString);
   void SetupApplicationFederate (void);
   void SetupCommandLine (CommandLine &cmd);

--- a/model/helics-application.cc
+++ b/model/helics-application.cc
@@ -19,8 +19,6 @@
 #include <fstream>
 #include <vector>
 
-#include <boost/algorithm/string/predicate.hpp>
-
 #include "ns3/log.h"
 #include "ns3/ipv4-address.h"
 #include "ns3/ipv6-address.h"
@@ -142,13 +140,14 @@ HelicsApplication::SetFilterName (const std::string &name)
   m_filter_id = helics_federate->registerFilter ("ns3_"+name, name);
   m_filterOp = std::make_shared<helics::MessageDestOperator> ([this](const std::string &src, const std::string &dest)
       {
-          if (boost::starts_with(src, helics_federate->getName())) {
+          const std::string &fedName = helics_federate->getName();
+          if (src.substr(0, fedName.size()) == fedName) {
               NS_LOG_INFO ("skipping rename, sent to self: " << src);
               return dest;
           }
           else {
               NS_LOG_INFO ("renaming: " << src);
-              return helics_federate->getName() + '/' + src;
+              return fedName + '/' + src;
           }
       });
   helics_federate->setFilterOperator (m_filter_id, m_filterOp);

--- a/wscript
+++ b/wscript
@@ -78,7 +78,7 @@ int main()
             os.path.abspath(os.path.join(conf.env['WITH_HELICS'], 'include')),
             os.path.abspath(os.path.join(conf.env['WITH_HELICS'], 'include/helics'))
         ]
-    conf.env['STLIBPATH_HELICS'] = [
+    conf.env['LIBPATH_HELICS'] = [
             os.path.abspath(os.path.join(conf.env['WITH_HELICS'], 'build', 'default')),
             os.path.abspath(os.path.join(conf.env['WITH_HELICS'], 'lib', 'helics')),
             os.path.abspath(os.path.join(conf.env['WITH_HELICS'], 'lib')),
@@ -92,10 +92,10 @@ int main()
     print retval
     if retval:
         conf.env['HELICS'] = retval
-        conf.env.append_value('STLIB_HELICS', ['helics-static', 'jsoncpp'])
+        conf.env.append_value('LIB_HELICS', ['helics-static'])
     else:
         conf.env['HELICS'] = conf.check(fragment=helics_test_code, lib='helics-staticd', libpath=conf.env['LIBPATH_HELICS'], use='HELICS')
-        conf.env.append_value('STLIB_HELICS', ['helics-staticd', 'jsoncppd'])
+        conf.env.append_value('LIB_HELICS', ['helics-staticd'])
 
     conf.report_optional_feature("helics", "HELICS Integration", conf.env['HELICS'], "HELICS library not found")
 

--- a/wscript
+++ b/wscript
@@ -78,7 +78,7 @@ int main()
             os.path.abspath(os.path.join(conf.env['WITH_HELICS'], 'include')),
             os.path.abspath(os.path.join(conf.env['WITH_HELICS'], 'include/helics'))
         ]
-    conf.env['LIBPATH_HELICS'] = [
+    conf.env['STLIBPATH_HELICS'] = [
             os.path.abspath(os.path.join(conf.env['WITH_HELICS'], 'build', 'default')),
             os.path.abspath(os.path.join(conf.env['WITH_HELICS'], 'lib', 'helics')),
             os.path.abspath(os.path.join(conf.env['WITH_HELICS'], 'lib')),
@@ -89,12 +89,13 @@ int main()
     conf.env['DEFINES_HELICS'] = ['NS3_HELICS']
 
     retval = conf.check_nonfatal(fragment=helics_test_code, lib='helics-static', libpath=conf.env['LIBPATH_HELICS'], use='HELICS')
+    print retval
     if retval:
         conf.env['HELICS'] = retval
-        conf.env.append_value('LIB_HELICS', 'helics-static')
+        conf.env.append_value('STLIB_HELICS', 'helics-static')
     else:
         conf.env['HELICS'] = conf.check(fragment=helics_test_code, lib='helics-staticd', libpath=conf.env['LIBPATH_HELICS'], use='HELICS')
-        conf.env.append_value('LIB_HELICS', 'helics-staticd')
+        conf.env.append_value('STLIB_HELICS', 'helics-staticd')
 
     conf.report_optional_feature("helics", "HELICS Integration", conf.env['HELICS'], "HELICS library not found")
 

--- a/wscript
+++ b/wscript
@@ -12,35 +12,7 @@ def options(opt):
                    help=('Path to HELICS for federated simulator integration'),
                    default='', dest='with_helics')
 
-REQUIRED_BOOST_LIBS = ['system', 'filesystem', 'program_options']
-
-def required_boost_libs(conf):
-    conf.env['REQUIRED_BOOST_LIBS'] += REQUIRED_BOOST_LIBS
-
-
 def configure(conf):
-    if not conf.env['LIB_BOOST']:
-        conf.report_optional_feature("helics", "helics integration", False,
-                                     "Required boost libraries not found")
-        return;
-
-    present_boost_libs = []
-    for boost_lib_name in conf.env['LIB_BOOST']:
-        if boost_lib_name.startswith("boost_"):
-            boost_lib_name = boost_lib_name[6:]
-        if boost_lib_name.endswith("-mt"):
-            boost_lib_name = boost_lib_name[:-3]
-        present_boost_libs.append(boost_lib_name)
-
-    missing_boost_libs = [lib for lib in REQUIRED_BOOST_LIBS if lib not in present_boost_libs]
-    if missing_boost_libs != []:
-        conf.report_optional_feature("helics", "helics integration", False,
-                                     "Required boost libraries not found, missing: %s" % ', '.join(missing_boost_libs))
-        # Add this module to the list of modules that won't be built
-        # if they are enabled.
-        conf.env['MODULES_NOT_BUILT'].append('helics')
-        return
-
     if Options.options.with_zmq:
         if os.path.isdir(Options.options.with_zmq):
             conf.msg("Checking for libzmq.so location", ("%s (given)" % Options.options.with_zmq))
@@ -162,7 +134,7 @@ def build(bld):
         ]
 
     if bld.env['ENABLE_HELICS']:
-        module.use.extend(['HELICS', 'BOOST', 'ZMQ'])
+        module.use.extend(['HELICS', 'ZMQ'])
 
     headers = bld(features='ns3header')
     headers.module = 'helics'

--- a/wscript
+++ b/wscript
@@ -92,10 +92,10 @@ int main()
     print retval
     if retval:
         conf.env['HELICS'] = retval
-        conf.env.append_value('STLIB_HELICS', 'helics-static')
+        conf.env.append_value('STLIB_HELICS', ['helics-static', 'jsoncpp'])
     else:
         conf.env['HELICS'] = conf.check(fragment=helics_test_code, lib='helics-staticd', libpath=conf.env['LIBPATH_HELICS'], use='HELICS')
-        conf.env.append_value('STLIB_HELICS', 'helics-staticd')
+        conf.env.append_value('STLIB_HELICS', ['helics-staticd', 'jsoncppd'])
 
     conf.report_optional_feature("helics", "HELICS Integration", conf.env['HELICS'], "HELICS library not found")
 


### PR DESCRIPTION
The default Azure VM build image now includes Boost 1.69, no need to install a copy any more.