### PR TITLE
Add includes to compiler scope and update print to python3

### DIFF
--- a/wscript
+++ b/wscript
@@ -89,15 +89,15 @@ int main()
     conf.env['DEFINES_HELICS'] = ['NS3_HELICS']
 
     retval = conf.check_nonfatal(fragment=helics_test_code, lib='helics-static', libpath=conf.env['LIBPATH_HELICS'], use='HELICS')
-    print(retval)
     if retval:
         conf.env['HELICS'] = retval
         conf.env.append_value('LIB_HELICS', ['helics-static'])
-        conf.env.append_value('INCLUDES', conf.env['INCLUDES_HELICS'])
+
     else:
         conf.env['HELICS'] = conf.check(fragment=helics_test_code, lib='helics-staticd', libpath=conf.env['LIBPATH_HELICS'], use='HELICS')
         conf.env.append_value('LIB_HELICS', ['helics-staticd'])
-        conf.env.append_value('INCLUDES', conf.env['INCLUDES_HELICS'])
+        
+    conf.env.append_value('INCLUDES', conf.env['INCLUDES_HELICS'])
 
     conf.report_optional_feature("helics", "HELICS Integration", conf.env['HELICS'], "HELICS library not found")
 

--- a/wscript
+++ b/wscript
@@ -89,13 +89,15 @@ int main()
     conf.env['DEFINES_HELICS'] = ['NS3_HELICS']
 
     retval = conf.check_nonfatal(fragment=helics_test_code, lib='helics-static', libpath=conf.env['LIBPATH_HELICS'], use='HELICS')
-    print retval
+    print(retval)
     if retval:
         conf.env['HELICS'] = retval
         conf.env.append_value('LIB_HELICS', ['helics-static'])
+        conf.env.append_value('INCLUDES', conf.env['INCLUDES_HELICS'])
     else:
         conf.env['HELICS'] = conf.check(fragment=helics_test_code, lib='helics-staticd', libpath=conf.env['LIBPATH_HELICS'], use='HELICS')
         conf.env.append_value('LIB_HELICS', ['helics-staticd'])
+        conf.env.append_value('INCLUDES', conf.env['INCLUDES_HELICS'])
 
     conf.report_optional_feature("helics", "HELICS Integration", conf.env['HELICS'], "HELICS library not found")
 


### PR DESCRIPTION
This allows things in the scratch directory (copy in helics-example.cc for instance) to be built with HELICS. 

Without this, the compiler would fail out with a "helics/helics.hpp" not found type error. 

This may not be the best way to address this issue, however it does work. Feel free to advise/adjust if a better method exists for adding to the includes paths in a more restricted manner (this adds them to the global includes structure for all of waf, but it was the only way I could find to make things in scratch find helics). 