### PR TITLE
Update master branch for HELICS 2.1.1 release

### DIFF
--- a/.ci/report-results.sh
+++ b/.ci/report-results.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+case ${PR_STATUS_REPORT} in
+    *Succeeded*)
+        BUILD_MESSAGE=":tada: **HELICS-Examples** integration test passed: [[build log]](https://dev.azure.com/HELICS-test/HELICS-Examples/_build/results?buildId=${BUILD_BUILDID}) [[commit]](https://github.com/GMLC-TDC/HELICS/commit/${HELICS_COMMITISH})"
+    ;;
+    *Failed*)
+        BUILD_MESSAGE=":confused: **HELICS-Examples** integration test had some problems: [[build log]](https://dev.azure.com/HELICS-test/HELICS-Examples/_build/results?buildId=${BUILD_BUILDID})  [[commit]](https://github.com/GMLC-TDC/HELICS/commit/${HELICS_COMMITISH})"
+    ;;
+esac
+
+# Report build status to PR
+if [[ "${BUILD_MESSAGE}" != "" ]]; then
+    echo "Reporting build status $PR_STATUS_REPORT to github.com/${HELICS_PR_SLUG}/issues/${HELICS_PR_NUM}"
+    body='{"body": "'${BUILD_MESSAGE}'"}'
+    curl -s -X POST \
+        -H "User-Agent: HELICS-bot" \
+        -H "Content-Type: application/json" \
+        -H "Accept: application/json" \
+        -H "Authorization: token ${HELICSBOT_GH_TOKEN}" \
+        -d "$body" \
+        https://api.github.com/repos/${HELICS_PR_SLUG}/issues/${HELICS_PR_NUM}/comments
+fi

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Prerequisites
 
-Install version 2.1+ of [HELICS](https://github.com/GMLC-TDC/HELICS); if building from source, be sure to set the CMake variable `JSONCPP_OBJLIB=ON` .
+Install version 2.1.1+ of [HELICS](https://github.com/GMLC-TDC/HELICS); if building from source, be sure to set the CMake variable `JSONCPP_OBJLIB=ON` .
 
 Get a recent copy of ns-3, ideally from their GitLab repository.
 

--- a/examples/fed-filter.cc
+++ b/examples/fed-filter.cc
@@ -38,12 +38,12 @@ int main (int argc, char *argv[])
     auto ret = app.helics_parse (argc, argv);
 
     helics::FederateInfo fi {};
-    if (ret == helics::helicsCLI11App::parse_return::help_return)
+    if (ret == helics::helicsCLI11App::parse_output::help_call)
     {
         fi.loadInfoFromArgs ("--help");
         return 0;
     }
-    else if (ret != helics::helicsCLI11App::parse_return::ok)
+    else if (ret != helics::helicsCLI11App::parse_output::ok)
     {
         return -1;
     }

--- a/examples/fed-sndrcv.cc
+++ b/examples/fed-sndrcv.cc
@@ -42,12 +42,12 @@ int main (int argc, char *argv[])
     auto ret = app.helics_parse (argc, argv);
 
     helics::FederateInfo fi {};
-    if (ret == helics::helicsCLI11App::parse_return::help_return)
+    if (ret == helics::helicsCLI11App::parse_output::help_call)
     {
         fi.loadInfoFromArgs ("--help");
         return 0;
     }
-    else if (ret != helics::helicsCLI11App::parse_return::ok)
+    else if (ret != helics::helicsCLI11App::parse_output::ok)
     {
         return -1;
     }


### PR DESCRIPTION
Updates the examples to work with a renamed enum in CLI11.