### PR TITLE
Update for HELICS 2.3 release

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -84,7 +84,6 @@ jobs:
   - script: |
       mv helics ns-3-dev/contrib
       cd ns-3-dev
-      ls src/internet/test/
       ./waf configure --disable-werror --with-helics=/usr/local --enable-modules=helics --enable-examples --enable-tests | tee azure_waf_configure.log
       ! grep -Fq "HELICS not enabled" azure_waf_configure.log
     displayName: 'Configure ns-3'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -84,6 +84,7 @@ jobs:
   - script: |
       mv helics ns-3-dev/contrib
       cd ns-3-dev
+      ls src/internet/test/
       ./waf configure --disable-werror --with-helics=/usr/local --enable-modules=helics --enable-examples --enable-tests | tee azure_waf_configure.log
       ! grep -Fq "HELICS not enabled" azure_waf_configure.log
     displayName: 'Configure ns-3'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,7 +57,7 @@ jobs:
   - task: CMake@1
     inputs:
       workingDirectory: HELICS-dependency/build
-      cmakeArgs: -GNinja -DCMAKE_BUILD_TYPE=Release -DJSONCPP_OBJLIB=ON -DBUILD_HELICS_TESTS=OFF -DBUILD_HELICS_EXAMPLES=OFF ..
+      cmakeArgs: -GNinja -DCMAKE_BUILD_TYPE=Release -DJSONCPP_OBJLIB=ON -DHELICS_BUILD_TESTS=OFF -DHELICS_BUILD_EXAMPLES=OFF ..
     displayName: 'Linux/macOS - Configure HELICS'
     condition: ne( variables['Agent.OS'], 'Windows_NT' )
   # -----------------------

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,7 +57,7 @@ jobs:
   - task: CMake@1
     inputs:
       workingDirectory: HELICS-dependency/build
-      cmakeArgs: -GNinja -DCMAKE_BUILD_TYPE=Release -DJSONCPP_OBJLIB=ON -DHELICS_BUILD_TESTS=OFF -DHELICS_BUILD_EXAMPLES=OFF ..
+      cmakeArgs: -GNinja -DCMAKE_BUILD_TYPE=Release -DHELICS_BUILD_TESTS=OFF -DHELICS_BUILD_EXAMPLES=OFF ..
     displayName: 'Linux/macOS - Configure HELICS'
     condition: ne( variables['Agent.OS'], 'Windows_NT' )
   # -----------------------

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,7 +57,7 @@ jobs:
   - task: CMake@1
     inputs:
       workingDirectory: HELICS-dependency/build
-      cmakeArgs: -GNinja -DCMAKE_BUILD_TYPE=Release -DHELICS_BUILD_TESTS=OFF -DHELICS_BUILD_EXAMPLES=OFF ..
+      cmakeArgs: -GNinja -DCMAKE_BUILD_TYPE=Release -DHELICS_BUILD_CXX_SHARED_LIB=ON -DHELICS_DISABLE_C_SHARED_LIB=ON -DHELICS_BUILD_APP_LIBRARY=OFF -DHELICS_BUILD_TESTS=OFF -DHELICS_BUILD_EXAMPLES=OFF ..
     displayName: 'Linux/macOS - Configure HELICS'
     condition: ne( variables['Agent.OS'], 'Windows_NT' )
   # -----------------------

--- a/examples/fed-filter.cc
+++ b/examples/fed-filter.cc
@@ -19,7 +19,6 @@
 #include <thread>
 #include <stdexcept>
 #include "helics/core/helicsCLI11.hpp"
-#include "helics/core/BrokerFactory.hpp"
 #include "helics/core/helicsVersion.hpp"
 
 int main (int argc, char *argv[])
@@ -28,12 +27,10 @@ int main (int argc, char *argv[])
     std::string myname = "fed";
     std::string srcEndpoint = "endpoint1";
     std::string dstEndpoint = "endpoint2";
-    std::string brokerArgs = "";
 
     app.add_option ("--name,-n", myname, "name of this federate");
     app.add_option ("--endpoint1,--source,-s", srcEndpoint, "name of the source endpoint");
     app.add_option ("--endpoint2,--dest,-d", dstEndpoint, "name of the destination endpoint");
-    app.add_option ("--startbroker", brokerArgs, "start a broker with the specified arguments");
 
     auto ret = app.helics_parse (argc, argv);
 
@@ -50,11 +47,6 @@ int main (int argc, char *argv[])
     fi.defName = "filterFedNS3";
     fi.loadInfoFromArgs(argc, argv);
     fi.setProperty(helics_property_time_delta, helics::loadTimeFromString("1s"));
-    std::shared_ptr<helics::Broker> brk;
-    if (app["--startbroker"]->count () > 0)
-    {
-        brk = helics::BrokerFactory::create(fi.coreType, brokerArgs);
-    }
 
     auto mFed = std::make_unique<helics::MessageFederate> (myname, fi);
     auto name = mFed->getName();
@@ -83,13 +75,5 @@ int main (int argc, char *argv[])
 
     }
     mFed->finalize ();
-    if (brk)
-    {
-        while (brk->isConnected())
-        {
-            std::this_thread::yield();
-        }
-        brk = nullptr;
-    }
     return 0;
 }

--- a/examples/fed-sndrcv.cc
+++ b/examples/fed-sndrcv.cc
@@ -19,7 +19,6 @@
 #include <thread>
 #include <stdexcept>
 #include "helics/core/helicsCLI11.hpp"
-#include "helics/core/BrokerFactory.hpp"
 #include "helics/core/helicsVersion.hpp"
 
 int main (int argc, char *argv[])
@@ -30,14 +29,12 @@ int main (int argc, char *argv[])
     std::string targetEndpoint = "endpoint1";
     std::string mysource = "endpoint1";
     std::string mydestination = "endpoint2";
-    std::string brokerArgs = "";
 
     app.add_option ("--name,-n", myname, "name of this federate");
     app.add_option ("--target,-t", targetFederate, "name of the target federate");
     app.add_option ("--endpoint,-e", targetEndpoint, "name of the target endpoint");
     app.add_option ("--source,-s", mysource, "name of the source endpoint");
     app.add_option ("--destination,-d", mydestination, "name of the destination endpoint");
-    app.add_option ("--startbroker", brokerArgs, "start a broker with the specified arguments");
 
     auto ret = app.helics_parse (argc, argv);
 
@@ -55,11 +52,6 @@ int main (int argc, char *argv[])
     std::string target = targetFederate + "/" + targetEndpoint;
     fi.loadInfoFromArgs(argc, argv);
     fi.setProperty(helics_property_int_log_level, 5);
-    std::shared_ptr<helics::Broker> brk;
-    if (app["--startbroker"]->count () > 0)
-    {
-        brk = helics::BrokerFactory::create(fi.coreType, brokerArgs);
-    }
 
     auto mFed = std::make_unique<helics::MessageFederate> (myname, fi);
     auto name = mFed->getName();
@@ -87,13 +79,5 @@ int main (int argc, char *argv[])
 
     }
     mFed->finalize ();
-    if (brk)
-    {
-        while (brk->isConnected())
-        {
-            std::this_thread::yield();
-        }
-        brk = nullptr;
-    }
     return 0;
 }

--- a/model/helics-application.cc
+++ b/model/helics-application.cc
@@ -402,14 +402,14 @@ HelicsApplication::Send (std::string dest, std::unique_ptr<helics::Message> mess
 void 
 HelicsApplication::EndpointCallback (helics::Endpoint id, helics::Time time)
 {
-  NS_LOG_FUNCTION (this << m_name << id.getHandle() << time);
+  NS_LOG_FUNCTION (this << m_name << id.getName() << time);
   DoEndpoint (id, time);
 }
  
 void 
 HelicsApplication::DoEndpoint (helics::Endpoint id, helics::Time time)
 {
-  NS_LOG_FUNCTION (this << id.getHandle() << time);
+  NS_LOG_FUNCTION (this << id.getName() << time);
   auto message = helics_federate->getMessage(id);
   DoEndpoint (id, time, std::move (message));
 }
@@ -417,7 +417,7 @@ HelicsApplication::DoEndpoint (helics::Endpoint id, helics::Time time)
 void 
 HelicsApplication::DoEndpoint (helics::Endpoint id, helics::Time time, std::unique_ptr<helics::Message> message)
 {
-  NS_LOG_FUNCTION (this << id.getHandle() << time << message->to_string());
+  NS_LOG_FUNCTION (this << id.getName() << time << message->to_string());
 }
 
 InetSocketAddress HelicsApplication::GetLocalInet (void) const

--- a/model/helics-filter-application.cc
+++ b/model/helics-filter-application.cc
@@ -68,7 +68,7 @@ HelicsFilterApplication::StopApplication (void)
 void
 HelicsFilterApplication::DoEndpoint (helics::Endpoint id, helics::Time time, std::unique_ptr<helics::Message> message)
 {
-  NS_LOG_FUNCTION (this << id.getHandle() << time << message->to_string());
+  NS_LOG_FUNCTION (this << id.getName() << time << message->to_string());
 
   Send (message->original_dest, std::make_unique<helics::Message> (*message));
 }

--- a/model/helics-static-sink-application.cc
+++ b/model/helics-static-sink-application.cc
@@ -97,7 +97,7 @@ HelicsStaticSinkApplication::DoFilter (std::unique_ptr<helics::Message> message)
 void
 HelicsStaticSinkApplication::DoEndpoint (helics::Endpoint id, helics::Time time, std::unique_ptr<helics::Message> message)
 {
-  NS_LOG_FUNCTION (this << id.getHandle() << time << message->to_string());
+  NS_LOG_FUNCTION (this << id.getName() << time << message->to_string());
 
   Send(m_destination, std::move (message));
 }

--- a/model/helics-static-source-application.cc
+++ b/model/helics-static-source-application.cc
@@ -100,7 +100,7 @@ HelicsStaticSourceApplication::DoFilter (std::unique_ptr<helics::Message> messag
 void
 HelicsStaticSourceApplication::DoEndpoint (helics::Endpoint id, helics::Time time, std::unique_ptr<helics::Message> message)
 {
-  NS_LOG_FUNCTION (this << id.getHandle() << time << message->to_string());
+  NS_LOG_FUNCTION (this << id.getName() << time << message->to_string());
 
   NS_FATAL_ERROR ("HelicsStaticSourceApplication should not receive endpoint events");
 }

--- a/wscript
+++ b/wscript
@@ -80,22 +80,42 @@ int main()
         ]
     conf.env['LIBPATH_HELICS'] = [
             os.path.abspath(os.path.join(conf.env['WITH_HELICS'], 'build', 'default')),
-            os.path.abspath(os.path.join(conf.env['WITH_HELICS'], 'lib', 'helics')),
             os.path.abspath(os.path.join(conf.env['WITH_HELICS'], 'lib')),
             os.path.abspath(os.path.join(conf.env['WITH_HELICS'], 'lib', 'helics')),
-            os.path.abspath(os.path.join(conf.env['WITH_HELICS'], 'lib64'))
+            os.path.abspath(os.path.join(conf.env['WITH_HELICS'], 'lib64')),
+            os.path.abspath(os.path.join(conf.env['WITH_HELICS'], 'lib64', 'helics'))
         ]
+    conf.env['RPATH_HELICS'] = [
+            os.path.abspath(os.path.join(conf.env['WITH_HELICS'], 'lib')),
+            os.path.abspath(os.path.join(conf.env['WITH_HELICS'], 'lib', 'helics')),
+            os.path.abspath(os.path.join(conf.env['WITH_HELICS'], 'lib64')),
+            os.path.abspath(os.path.join(conf.env['WITH_HELICS'], 'lib64', 'helics'))
+    ]
 
     conf.env['DEFINES_HELICS'] = ['NS3_HELICS']
 
-    retval = conf.check_nonfatal(fragment=helics_test_code, lib='helics-static', libpath=conf.env['LIBPATH_HELICS'], use='HELICS')
+    # Check for helics-shared library
+    retval = conf.check_nonfatal(fragment=helics_test_code, lib='helics-shared', libpath=conf.env['LIBPATH_HELICS'], use='HELICS')
     if retval:
         conf.env['HELICS'] = retval
-        conf.env.append_value('LIB_HELICS', ['helics-static'])
-
+        conf.env.append_value('LIB_HELICS', ['helics-shared'])
     else:
-        conf.env['HELICS'] = conf.check(fragment=helics_test_code, lib='helics-staticd', libpath=conf.env['LIBPATH_HELICS'], use='HELICS')
-        conf.env.append_value('LIB_HELICS', ['helics-staticd'])
+        # Check for debug variant of helics-shared library
+        retval = conf.check_nonfatal(fragment=helics_test_code, lib='helics-sharedd', libpath=conf.env['LIBPATH_HELICS'], use='HELICS')
+        if retval:
+            conf.env['HELICS'] = retval
+            conf.env.append_value('LIB_HELICS', ['helics-sharedd'])
+        else:
+            # Fall-back to support pre-2.3 versions of HELICS
+            # Look for helics-static library
+            retval = conf.check_nonfatal(fragment=helics_test_code, lib='helics-static', libpath=conf.env['LIBPATH_HELICS'], use='HELICS')
+            if retval:
+                conf.env['HELICS'] = retval
+                conf.env.append_value('LIB_HELICS', ['helics-static'])
+            else:
+                # Check for debug variant of helics-static library
+                retval = conf.check(fragment=helics_test_code, lib='helics-staticd', libpath=conf.env['LIBPATH_HELICS'], use='HELICS')
+                conf.env.append_value('LIB_HELICS', ['helics-staticd'])
         
     conf.env.append_value('INCLUDES', conf.env['INCLUDES_HELICS'])
 


### PR DESCRIPTION
This update changes the CMake options that were renamed in HELICS 2.3 that are used by the CI system for installing a copy of HELICS to test the ns-3 module with. It also removes the use of some deprecated functions and some practices that are not recommended. Support is also added the switch in HELICS 2.3 to using helics-shared instead of helics-static (though the helics-ns3 module should be backwards compatible with older versions of HELICS).