### PR TITLE
Change federate type to CombinationFederate

### DIFF
--- a/examples/fed-pubsub.cc
+++ b/examples/fed-pubsub.cc
@@ -1,0 +1,74 @@
+/*
+Copyright (c) 2017-2019, Battelle Memorial Institute; Lawrence Livermore National Security, LLC; Alliance for Sustainable Energy, LLC.  See the top-level NOTICE for additional details. All rights reserved.
+
+SPDX-License-Identifier: BSD-3-Clause
+*/
+
+#include "helics/application_api/ValueFederate.hpp"
+#include "helics/application_api/Inputs.hpp"
+#include <algorithm>
+#include <fstream>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <regex>
+#include <set>
+#include <thread>
+#include <stdexcept>
+#include "helics/core/helicsCLI11.hpp"
+#include "helics/core/helicsVersion.hpp"
+
+int main (int argc, char *argv[])
+{
+    helics::helicsCLI11App app ("PubSub NS3 Example", "PubSubNS3Example");
+    std::string myname = "fed";
+    std::string publishKey = "ns3_test_value";
+
+    app.add_option ("--name,-n", myname, "name of this federate");
+    app.add_option ("--key,-k", publishKey, "name of the key to publish on");
+
+    auto ret = app.helics_parse (argc, argv);
+
+    helics::FederateInfo fi {};
+    if (ret == helics::helicsCLI11App::parse_output::help_call)
+    {
+        fi.loadInfoFromArgs ("--help");
+        return 0;
+    }
+    else if (ret != helics::helicsCLI11App::parse_output::ok)
+    {
+        return -1;
+    }
+
+    fi.loadInfoFromArgs (argc, argv);
+    fi.setProperty (helics_property_int_log_level, 5);
+
+    auto mFed = std::make_unique<helics::ValueFederate> (myname, fi);
+    const auto name = mFed->getName();
+    std::cout << " registering publication '" << publishKey << "' for " << name<<'\n';
+    auto &pub = mFed->registerGlobalPublication<std::string> (publishKey);
+    std::cout << " registering subscription '" << publishKey << "' for " << name<<'\n';
+    auto &sub = mFed->registerSubscription (publishKey);
+
+    std::cout << "entering init State\n";
+    mFed->enterInitializingMode ();
+    std::cout << "entered init State\n";
+    mFed->enterExecutingMode ();
+    std::cout << "entered exec State\n";
+    for (int i=1; i<10; ++i)
+    {
+        const std::string message = "publishing message on "+publishKey+" at time " + std::to_string (i);
+        mFed->publish (pub, message);
+        std::cout << message << std::endl;
+        const auto newTime = mFed->requestTime (i);
+        std::cout << "processed time " << static_cast<double> (newTime) << "\n";
+        while (sub.checkUpdate ())
+        {
+            const auto nmessage = sub.getValue<std::string> ();
+            std::cout << "received publication on key " << sub.getKey () << " at " << static_cast<double> (sub.getLastUpdate ()) << " ::" << nmessage << '\n';
+        }
+
+    }
+    mFed->finalize ();
+    return 0;
+}

--- a/examples/wscript
+++ b/examples/wscript
@@ -15,3 +15,6 @@ def build(bld):
 
     obj = bld.create_ns3_program('fed-sndrcv', ['helics'])
     obj.source = 'fed-sndrcv.cc'
+
+    obj = bld.create_ns3_program('fed-pubsub', ['helics'])
+    obj.source = 'fed-pubsub.cc'

--- a/helper/helics-helper.cc
+++ b/helper/helics-helper.cc
@@ -42,7 +42,7 @@ HelicsHelper::SetupFederate(void) {
     if (!coreinit.empty()) {
         fi.coreInitString = coreinit;
     }
-    helics_federate = std::make_shared<helics::MessageFederate>(name, fi);
+    helics_federate = std::make_shared<helics::CombinationFederate>(name, fi);
 }
 
 // Some of the recognized args:
@@ -65,14 +65,14 @@ void
 HelicsHelper::SetupFederate(int argc, char **argv)
 {
   helics::FederateInfo fi (argc, argv);
-  helics_federate = std::make_shared<helics::MessageFederate> (name, fi);
+  helics_federate = std::make_shared<helics::CombinationFederate> (name, fi);
 }
 
 void
 HelicsHelper::SetupFederate(std::string &jsonString)
 {
   helics::FederateInfo fi = helics::loadFederateInfo (jsonString);
-  helics_federate = std::make_shared<helics::MessageFederate> (name, fi);
+  helics_federate = std::make_shared<helics::CombinationFederate> (name, fi);
 }
 
 void

--- a/model/helics.cc
+++ b/model/helics.cc
@@ -9,7 +9,7 @@ SPDX-License-Identifier: BSD-3-Clause
 
 namespace ns3 {
 
-std::shared_ptr<helics::MessageFederate> helics_federate;
+std::shared_ptr<helics::CombinationFederate> helics_federate;
 helics::Endpoint helics_endpoint;
 
 std::ostream& operator << (std::ostream& stream, const helics::Message &message)

--- a/model/helics.h
+++ b/model/helics.h
@@ -15,7 +15,7 @@ SPDX-License-Identifier: BSD-3-Clause
 
 namespace ns3 {
 
-extern std::shared_ptr<helics::MessageFederate> helics_federate;
+extern std::shared_ptr<helics::CombinationFederate> helics_federate;
 extern helics::Endpoint helics_endpoint;
 
 std::ostream& operator << (std::ostream& stream, const helics::Message &message);


### PR DESCRIPTION
Add support for using pubsub data as well as messages.

In order to run the example, ns3-sndrcv can be used.  I wasn't sure if I should change the name or what so I just left it alone.