### PR TITLE
Update helics-ns3 to build with HELICS 3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         run: brew install zeromq boost
       - uses: gmlc-tdc/helics-action/install@main
         with:
-          version: 'v2'
+          version: 'v3'
           build_from_source: 'true'
 
       # Clone ns-3 and checkout this repository to the contrib subfolder

--- a/examples/fed-filter.cc
+++ b/examples/fed-filter.cc
@@ -42,12 +42,12 @@ int main (int argc, char *argv[])
     }
     fi.defName = "filterFedNS3";
     fi.loadInfoFromArgs(argc, argv);
-    fi.setProperty(helics_property_time_delta, helics::loadTimeFromString("1s"));
+    fi.setProperty(HELICS_PROPERTY_TIME_DELTA, helics::loadTimeFromString("1s"));
 
     auto mFed = std::make_unique<helics::MessageFederate> (myname, fi);
     auto name = mFed->getName();
     std::cout << " registering endpoint '" << srcEndpoint << "' for " << name<<'\n';
-    auto &idsource = mFed->registerEndpoint(srcEndpoint, "");
+    auto &sourceEp = mFed->registerEndpoint(srcEndpoint, "");
     std::cout << " registering endpoint '" << dstEndpoint << "' for " << name<<'\n';
     (void)mFed->registerEndpoint(dstEndpoint, "");
 
@@ -58,7 +58,7 @@ int main (int argc, char *argv[])
     std::cout << "entered exec State\n";
     for (int i=1; i<10; ++i) {
         std::string message = "message sent from "+name+"/"+srcEndpoint+" to "+name+"/"+dstEndpoint+" at time " + std::to_string(i);
-        mFed->sendMessage(idsource, name+"/"+dstEndpoint, message.data(), message.size());
+        sourceEp.sendTo(message.data(), message.size(), name+"/"+dstEndpoint);
         std::cout << message << std::endl;
         std::cout << "requesting time " << static_cast<double> (i) << "\n";
         auto newTime = mFed->requestTime (i);

--- a/examples/fed-pubsub.cc
+++ b/examples/fed-pubsub.cc
@@ -44,7 +44,7 @@ int main (int argc, char *argv[])
 
     cmd.Parse (args);
     helicsHelper.SetupFederate (args);
-    helics_federate->setProperty (helics_property_int_log_level, 5);
+    helics_federate->setProperty (HELICS_PROPERTY_INT_LOG_LEVEL, 5);
 
     const auto name = helics_federate->getName();
     std::cout << " registering publication '" << publishKey << "' for " << name<<'\n';
@@ -60,14 +60,14 @@ int main (int argc, char *argv[])
     for (int i=1; i<10; ++i)
     {
         const std::string message = "publishing message on "+publishKey+" at time " + std::to_string (i);
-        helics_federate->publish (pub, message);
+        pub.publish (message);
         std::cout << message << std::endl;
         const auto newTime = helics_federate->requestTime (i);
         std::cout << "processed time " << static_cast<double> (newTime) << "\n";
         while (sub.checkUpdate ())
         {
             const auto nmessage = sub.getValue<std::string> ();
-            std::cout << "received publication on key " << sub.getKey () << " at " << static_cast<double> (sub.getLastUpdate ()) << " ::" << nmessage << '\n';
+            std::cout << "received publication on key " << sub.getDisplayName () << " at " << static_cast<double> (sub.getLastUpdate ()) << " ::" << nmessage << '\n';
         }
 
     }

--- a/examples/fed-sndrcv.cc
+++ b/examples/fed-sndrcv.cc
@@ -47,12 +47,12 @@ int main (int argc, char *argv[])
 
     std::string target = targetFederate + "/" + targetEndpoint;
     fi.loadInfoFromArgs(argc, argv);
-    fi.setProperty(helics_property_int_log_level, 5);
+    fi.setProperty(HELICS_PROPERTY_INT_LOG_LEVEL, 5);
 
     auto mFed = std::make_unique<helics::MessageFederate> (myname, fi);
     auto name = mFed->getName();
     std::cout << " registering endpoint '" << mysource << "' for " << name<<'\n';
-    auto &idsource = mFed->registerEndpoint(mysource, "");
+    auto &sourceEp = mFed->registerEndpoint(mysource, "");
     std::cout << " registering endpoint '" << mydestination << "' for " << name<<'\n';
     (void)mFed->registerEndpoint(mydestination, "");
 
@@ -63,7 +63,7 @@ int main (int argc, char *argv[])
     std::cout << "entered exec State\n";
     for (int i=1; i<10; ++i) {
         std::string message = "message sent from "+name+"/"+mysource+" to "+target+" at time " + std::to_string(i);
-        mFed->sendMessage(idsource, target, message.data(), message.size());
+        sourceEp.sendTo(message.data(), message.size(), target);
         std::cout << message << std::endl;
         auto newTime = mFed->requestTime (i);
         std::cout << "processed time " << static_cast<double> (newTime) << "\n";

--- a/helper/helics-helper.cc
+++ b/helper/helics-helper.cc
@@ -17,7 +17,8 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "ns3/helics-static-source-application.h"
 #include "ns3/helics-helper.h"
 
-#include "helics/core/core-types.hpp"
+#include "helics/core/CoreTypes.hpp"
+#include "helics/application_api/typeOperations.hpp"
 
 namespace ns3 {
 
@@ -38,7 +39,7 @@ HelicsHelper::SetupFederate(void) {
     helics::FederateInfo fi{};
     fi.broker = broker;
     fi.coreType = helics::coreTypeFromString(core);
-    fi.setProperty(helics_property_time_delta, helics::loadTimeFromString("1ns"));
+    fi.setProperty(HELICS_PROPERTY_TIME_DELTA, helics::loadTimeFromString("1ns"));
     if (!coreinit.empty()) {
         fi.coreInitString = coreinit;
     }

--- a/helper/helics-helper.cc
+++ b/helper/helics-helper.cc
@@ -18,6 +18,7 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "ns3/helics-helper.h"
 
 #include "helics/core/CoreTypes.hpp"
+#include "helics/application_api/timeOperations.hpp"
 #include "helics/application_api/typeOperations.hpp"
 
 namespace ns3 {

--- a/model/helics-application.cc
+++ b/model/helics-application.cc
@@ -137,10 +137,10 @@ void HelicsApplication::SetupFilterApplication (const helics::Filter &filterInst
 {
 	  NS_LOG_FUNCTION (this << epInstance.getName());
 	  m_filter_id = filterInstance;
-	  m_endpoint_id = epInstance;
+	  m_endpoint = epInstance;
 	  SetName(epInstance.getName());
 	  std::function<void(helics::Endpoint,helics::Time)> func = std::bind (&HelicsApplication::EndpointCallback, this, std::placeholders::_1, std::placeholders::_2);
-	  helics_federate->setMessageNotificationCallback(m_endpoint_id, func);
+	  helics_federate->setMessageNotificationCallback(m_endpoint, func);
 }
 
 void
@@ -170,16 +170,16 @@ HelicsApplication::SetEndpointName (const std::string &name, bool is_global)
   NS_LOG_FUNCTION (this << name << is_global);
   SetName(name);
   if (is_global) {
-    m_endpoint_id = helics_federate->registerGlobalEndpoint (name);
+    m_endpoint = helics_federate->registerGlobalEndpoint (name);
   }
   else {
-    m_endpoint_id = helics_federate->registerEndpoint (name);
+    m_endpoint = helics_federate->registerEndpoint (name);
   }
   using std::placeholders::_1;
   using std::placeholders::_2;
   std::function<void(helics::Endpoint,helics::Time)> func;
   func = std::bind (&HelicsApplication::EndpointCallback, this, _1, _2);
-  helics_federate->setMessageNotificationCallback(m_endpoint_id, func);
+  helics_federate->setMessageNotificationCallback(m_endpoint, func);
 }
 
 void
@@ -189,7 +189,7 @@ HelicsApplication::SetEndpoint (helics::Endpoint &ep) {
   using std::placeholders::_2;
   std::function<void(helics::Endpoint,helics::Time)> func;
   func = std::bind (&HelicsApplication::EndpointCallback, this, _1, _2);
-  m_endpoint_id = ep;
+  m_endpoint = ep;
   helics_federate->setMessageNotificationCallback(ep, func);
 }
 
@@ -297,7 +297,7 @@ HelicsApplication::StopApplication ()
 }
 
 static uint8_t
-char_to_uint8_t (char c)
+stdbyte_to_uint8_t (std::byte c)
 {
   return uint8_t(c);
 }
@@ -331,7 +331,7 @@ HelicsApplication::Send (std::string dest, std::unique_ptr<helics::Message> mess
   size_t total_size = message->data.size();
   uint8_t *buffer = new uint8_t[total_size];
   uint8_t *buffer_ptr = buffer;
-  std::transform (message->data.begin(), message->data.end(), buffer_ptr, char_to_uint8_t);
+  std::transform (message->data.begin(), message->data.end(), buffer_ptr, stdbyte_to_uint8_t);
   p = Create<Packet> (buffer, total_size);
   NS_LOG_INFO("buffer='" << p << "'");
   delete [] buffer;

--- a/model/helics-application.h
+++ b/model/helics-application.h
@@ -120,7 +120,7 @@ protected:
   virtual void DoEndpoint (helics::Endpoint id, helics::Time time, std::unique_ptr<helics::Message> message);
   virtual void DoRead (std::unique_ptr<helics::Message> message);
 
-  helics::Endpoint m_endpoint_id;
+  helics::Endpoint m_endpoint;
 
 private:
   /**

--- a/model/helics-filter-application.cc
+++ b/model/helics-filter-application.cc
@@ -85,7 +85,7 @@ HelicsFilterApplication::DoRead (std::unique_ptr<helics::Message> message)
   NS_LOG_FUNCTION (this << message->to_string());
 
   message->dest = message->original_dest;
-  helics_federate->sendMessage (m_endpoint_id, std::move (message));
+  m_endpoint.send (std::move (message));
 }
 
 } // Namespace ns3

--- a/model/helics-static-source-application.cc
+++ b/model/helics-static-source-application.cc
@@ -118,7 +118,7 @@ HelicsStaticSourceApplication::DoRead (std::unique_ptr<helics::Message> message)
 
   NS_LOG_INFO ("sending message on to " << m_destination);
 
-  helics_federate->sendMessage (m_endpoint_id, m_destination, message->data.data(), message->data.size());
+  m_endpoint.sendTo (message->data, m_destination);
 }
 
 } // Namespace ns3

--- a/wscript
+++ b/wscript
@@ -98,9 +98,8 @@ int main()
     conf.env['DEFINES_HELICS'] = ['NS3_HELICS']
 
     # Look for HELICS library
-    # HELICS 2.3+: helics-shared, helics-sharedd
-    # HELICS pre-2.3: helics-static, helics-staticd
-    possible_helics_lib_names = ['helics-shared', 'helics-sharedd', 'helics-static', 'helics-staticd']
+    # HELICS 3: helicscpp, helicscppd
+    possible_helics_lib_names = ['helicscpp', 'helicscppd']
     for try_helics_lib in possible_helics_lib_names:
         retval = conf.check_nonfatal(fragment=helics_test_code, lib=try_helics_lib, libpath=conf.env['LIBPATH_HELICS'], use='HELICS')
         if retval:

--- a/wscript
+++ b/wscript
@@ -122,7 +122,7 @@ int main()
     if conf.env['HELICS']:
         for index,flag in enumerate(conf.env['CXXFLAGS']):
             if 'c++11' in flag:
-                conf.env['CXXFLAGS'][index] = '-std=c++14'
+                conf.env['CXXFLAGS'][index] = '-std=c++17'
                 break
         print(conf.env['CXXFLAGS'])
 

--- a/wscript
+++ b/wscript
@@ -118,7 +118,7 @@ int main()
         # if they are enabled.
         conf.env['MODULES_NOT_BUILT'].append('helics')
 
-    # if HELICS is enabled, we must use c++14 instead of c++11
+    # if HELICS is enabled, we must use c++17 instead of c++11
     if conf.env['HELICS']:
         for index,flag in enumerate(conf.env['CXXFLAGS']):
             if 'c++11' in flag:


### PR DESCRIPTION
These changes make so that `helics-ns3` can build using HELICS 3.

@phlptp can you check that I used the right HELICS 3 functions? In particular, I'm not sure about the replacement for `sub.getKey` with `sub.getDisplayName()`, and `helics_federate->sendMessage (m_endpoint_id, m_destination, message->data.data(), message->data.size());` to `m_endpoint.sendTo (message->data, m_destination);`